### PR TITLE
Troubleshoot GAQL CLI Version Command Error

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ program
   .command('validate')
   .description('Validate GAQL queries in a file or from stdin')
   .argument('[file]', 'File containing GAQL queries (if omitted, reads from stdin)')
-  .option('-v, --api-version <version>', 'Google Ads API version (19, 20, or 21)', '21')
+  .option('-a, --api-version <version>', 'Google Ads API version (19, 20, or 21)', '21')
   .option('-f, --format <format>', 'Output format (text, json, llm, or rich)', 'text')
   .option('--no-color', 'Disable colored output')
   .action(validateCommand);


### PR DESCRIPTION
This pull request makes a minor update to the CLI for the `validate` command by changing the short flag for the `--api-version` option from `-v` to `-a`. This helps avoid potential conflicts or confusion with other commonly used flags.

* Changed the short flag for the `--api-version` option in the `validate` command from `-v` to `-a` in `packages/cli/src/index.ts`.