### PR TITLE
release of @gaql/core@0.1.4, @gaql/cli@0.1.4, gaql-vscode@0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "overrides": {
       "@isaacs/brace-expansion": "5.0.1",
       "glob": "^13.0.1",
-      "js-yaml": "^4.1.0",
+      "js-yaml": "^4.1.1",
       "jws": "4.0.1",
       "lodash": "4.17.23",
       "node-forge": "1.3.3",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2026-02-05
+
+### Changed
+
+- Update `@gaql/core` to `0.1.4`
+
 ## [0.1.3] - 2025-10-26
 
 ## Changed
@@ -51,6 +57,7 @@
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaql/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI tool for Google Ads Query Language (GAQL) validation and type generation",
   "license": "MIT",
   "author": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-All notable changes to @gaql/core will be documented in this file.
+## [0.1.4] - 2026-02-05
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### Changed
+
+- Update dependencies
 
 ## [0.1.3] - 2025-10-26
 
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaql/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Core validation and schema logic for Google Ads Query Language (GAQL)",
   "license": "MIT",
   "author": {

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2026-02-05
+
+### Changed
+
+- Update `@gaql/core` to `0.1.4`
+
 ## [0.1.3] - 2025-10-26
 
 ### Changed
@@ -50,6 +56,7 @@
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.1

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gaql-vscode",
   "displayName": "Google Ads Query Language",
   "description": "Language support for Google Ads Query Language (GAQL): validation, autocomplete, IntelliSense, and diagnostics",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "kage1020",
   "author": {
     "name": "kage1020"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@isaacs/brace-expansion': 5.0.1
   glob: ^13.0.1
-  js-yaml: ^4.1.0
+  js-yaml: ^4.1.1
   jws: 4.0.1
   lodash: 4.17.23
   node-forge: 1.3.3
@@ -1445,8 +1445,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -2726,7 +2726,7 @@ snapshots:
       '@textlint/types': 15.2.3
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.14.1
+      js-yaml: 4.1.1
       lodash: 4.17.23
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -3757,7 +3757,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
@@ -4094,7 +4094,7 @@ snapshots:
   rc-config-loader@4.1.3:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:


### PR DESCRIPTION
This pull request updates the `js-yaml` dependency to version 4.1.1 across the project and bumps the version numbers for the CLI, core, and VSCode extension packages to 0.1.4. These changes ensure the project uses the latest patch of `js-yaml` and keep the package versions in sync.

Dependency updates:

* Updated the `js-yaml` dependency from version 4.1.0 to 4.1.1 in `package.json`, `pnpm-lock.yaml`, and all relevant dependency overrides and snapshots. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R35) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-R10) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1448-R1449) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2729-R2729) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3760-R3760) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4097-R4097)

Version bumps:

* Bumped the version of `@gaql/cli` to 0.1.4 in `packages/cli/package.json`.
* Bumped the version of `@gaql/core` to 0.1.4 in `packages/core/package.json`.
* Bumped the version of the VSCode extension to 0.1.4 in `packages/vscode-extension/package.json`.