### PR TITLE
fix: resolve polynomial regex (ReDoS) vulnerabilities

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -321,7 +321,10 @@ export function extractWhereClause(query: string): string | null {
     let afterOrder = orderIdx + 5;
     while (afterOrder < upper.length && isWhitespaceChar(upper.charCodeAt(afterOrder)))
       afterOrder++;
-    if (upper.startsWith('BY', afterOrder) && (afterOrder + 2 >= upper.length || !isIdentCharCode(upper.charCodeAt(afterOrder + 2)))) {
+    if (
+      upper.startsWith('BY', afterOrder) &&
+      (afterOrder + 2 >= upper.length || !isIdentCharCode(upper.charCodeAt(afterOrder + 2)))
+    ) {
       end = orderIdx;
     }
   }

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,3 +1,4 @@
+import { extractDottedIdentifiers, extractSelectClause, extractWhereClause } from './parser.js';
 import {
   getFieldsForResource,
   getResourceNames,
@@ -48,7 +49,32 @@ export interface ValidationResult {
 function stripTemplateLiteralInterpolations(query: string): string {
   // Replace ${...} with a placeholder to avoid validating interpolated expressions
   // We use a string literal placeholder to maintain query structure
-  return query.replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, "'__PLACEHOLDER__'");
+  // Manual parsing instead of regex to avoid polynomial backtracking (ReDoS)
+  const parts: string[] = [];
+  let i = 0;
+  while (i < query.length) {
+    if (query[i] === '$' && i + 1 < query.length && query[i + 1] === '{') {
+      // Found ${, find the matching } by tracking brace depth
+      let depth = 1;
+      let j = i + 2;
+      while (j < query.length && depth > 0) {
+        if (query[j] === '{') depth++;
+        else if (query[j] === '}') depth--;
+        j++;
+      }
+      if (depth === 0) {
+        parts.push("'__PLACEHOLDER__'");
+        i = j;
+      } else {
+        parts.push(query[i]);
+        i++;
+      }
+    } else {
+      parts.push(query[i]);
+      i++;
+    }
+  }
+  return parts.join('');
 }
 
 /**
@@ -126,9 +152,9 @@ export function validateQuery<T extends SupportedApiVersion>(
   }
 
   // Validate fields in SELECT clause
-  const selectMatch = cleanedQuery.match(/\bSELECT\s+(.+?)\s+FROM/is);
-  if (selectMatch) {
-    const selectFields = selectMatch[1]
+  const selectClause = extractSelectClause(cleanedQuery);
+  if (selectClause) {
+    const selectFields = selectClause
       .split(',')
       .map((f) => f.trim())
       .filter((f) => f.length > 0);
@@ -158,12 +184,10 @@ export function validateQuery<T extends SupportedApiVersion>(
   }
 
   // Validate fields in WHERE clause
-  const whereMatch = cleanedQuery.match(/\bWHERE\s+(.+?)(\s+ORDER\s+BY|\s+LIMIT|$)/is);
-  if (whereMatch) {
-    const whereClause = whereMatch[1];
+  const whereClause = extractWhereClause(cleanedQuery);
+  if (whereClause) {
     // Extract field references (e.g., campaign.id, metrics.clicks)
-    const fieldRegex = /([a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*)/gi;
-    const whereFields = whereClause.match(fieldRegex) || [];
+    const whereFields = extractDottedIdentifiers(whereClause);
 
     const validFields = getFieldsForResource(resourceName, version);
     const validFieldDescriptions = validFields.map((f) => f.description);
@@ -273,12 +297,18 @@ export function validateText<T extends SupportedApiVersion>(
   const results: Array<ValidationResult & { query: string; line: number }> = [];
 
   // Extract queries from template literals
-  const queryRegex = /`([^`]*SELECT[^`]*FROM[^`]*)`/gi;
+  // Use a simple regex to match backtick strings, then check for SELECT/FROM separately
+  // to avoid polynomial backtracking (ReDoS) with nested quantifiers
+  const backtickRegex = /`([^`]*)`/g;
   let match: RegExpExecArray | null;
 
   // biome-ignore lint/suspicious/noAssignInExpressions: needed for regex matching
-  while ((match = queryRegex.exec(text)) !== null) {
-    const query = match[1].trim();
+  while ((match = backtickRegex.exec(text)) !== null) {
+    const content = match[1];
+    if (!/SELECT/i.test(content) || !/FROM/i.test(content)) {
+      continue;
+    }
+    const query = content.trim();
     const startPos = match.index;
     const lineNumber = text.substring(0, startPos).split('\n').length - 1;
 


### PR DESCRIPTION
## Summary

- Replace all CodeQL-flagged polynomial regular expressions in `packages/core/src/parser.ts` and `packages/core/src/validator.ts` with linear-time alternatives
- Eliminate ReDoS (Regular Expression Denial of Service) attack vectors caused by nested quantifiers and lazy/greedy interactions

### Changes

| Location | Issue | Fix |
|---|---|---|
| `stripTemplateLiteralInterpolations` | `\$\{(?:[^{}]\|\{[^}]*\})*\}` nested alternation | Manual brace-depth tracking parser |
| `validateText` | `` `([^`]*SELECT[^`]*FROM[^`]*)` `` triple `[^`]*` | Simple backtick extraction + separate keyword tests |
| `extractSelectFields` | `SELECT\s+(.+?)\s+FROM` lazy `.+?` + `\s+` | `indexOf`-based keyword search (`extractSelectClause`) |
| `extractWhereFields` | `WHERE\s+(.+?)(\s+ORDER\s+BY\|\s+LIMIT\|$)` lazy `.+?` + `\s+` | `indexOf`-based keyword search (`extractWhereClause`) |
| `extractWhereFields` | `([a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*)` quadratic backtracking | charCode-based linear scanner (`extractDottedIdentifiers`) |

## Test plan

- [x] All 218 core tests pass
- [x] All 42 CLI tests pass
- [x] All 18 VS Code extension tests pass
- [x] Lint passes with no errors
- [x] Build succeeds for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)