### PR TITLE
Release of 0.1.15

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint && pnpm build && pnpm test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,17 @@
 {
   "biome.enabled": true,
+  "prettier.enable": false,
+  "eslint.enable": false,
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "biomejs.biome",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.organizeImports.biome": "explicit",
+    "source.fixAll.biome": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "search.exclude": {

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ gaql validate query.ts --format json
 ### Programmatic Usage
 
 ```typescript
-import { validateQuery, setApiVersion } from '@gaql/core';
-
-// Set API version
-setApiVersion('21');
+import { validateQuery } from '@gaql/core';
 
 // Validate a query
 const query = `

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "clean": "turbo run clean && rm -rf node_modules .turbo",
-    "format": "turbo run format"
+    "clean": "turbo run clean && rm -rf .turbo",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.0",
+    "husky": "^9.1.7",
     "turbo": "^2.5.8",
     "typescript": "^5.9.3",
     "vitest": "^4.0.3"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2025-10-29
+
+### Changed
+
+- Update `@gaql/core` to v0.1.4
+
 ## [0.1.3] - 2025-10-26
 
 ## Changed
@@ -51,6 +57,7 @@
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/cli-v0.1.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaql/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI tool for Google Ads Query Language (GAQL) validation and type generation",
   "license": "MIT",
   "author": {
@@ -39,8 +39,7 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "clean": "rm -rf dist *.tsbuildinfo",
-    "lint": "biome check .",
-    "format": "biome format --write .",
+    "lint": "biome check --write --assist-enabled=true .",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -1,3 +1,4 @@
+// @gaql-disable
 import * as fs from 'node:fs/promises';
 import * as core from '@gaql/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as core from '@gaql/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { validateCommand } from './validate.js';
 
 // Mock process.exit to prevent tests from exiting
 const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
@@ -49,8 +50,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       // Mock console.log to capture output
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -65,8 +64,6 @@ describe('validate command', () => {
 
     it('should handle non-existent file', async () => {
       vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT: no such file or directory'));
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -83,8 +80,6 @@ describe('validate command', () => {
       `;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -112,8 +107,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'json', color: false });
@@ -134,8 +127,6 @@ describe('validate command', () => {
 
     it('should handle empty file', async () => {
       vi.mocked(fs.readFile).mockResolvedValue('');
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -161,8 +152,6 @@ describe('validate command', () => {
       `;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -191,27 +180,19 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const setApiVersionSpy = vi.spyOn(core, 'setApiVersion');
-
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '19', format: 'text', color: false });
 
-      expect(setApiVersionSpy).toHaveBeenCalledWith('19');
       expect(mockExit).toHaveBeenCalledWith(0);
 
       consoleLogSpy.mockRestore();
-      setApiVersionSpy.mockRestore();
     });
 
     it('should respect --format option for JSON', async () => {
       const mockContent = `const query = \`SELECT campaign.id FROM campaign\`;`;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -232,8 +213,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'text', color: false });
@@ -252,8 +231,6 @@ describe('validate command', () => {
       const mockContent = `const query = \`SELECT campaign.id FROM campaign\`;`;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -277,8 +254,6 @@ describe('validate command', () => {
       const mockContent = `const query = \`SELECT campaign.invalid_field FROM campaign\`;`;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -305,8 +280,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'rich', color: false });
@@ -327,8 +300,6 @@ describe('validate command', () => {
       const mockContent = `const query = \`SELECT campaign.invalid_field FROM campaign\`;`;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -354,20 +325,14 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const setApiVersionSpy = vi.spyOn(core, 'setApiVersion');
-
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'text', color: false });
 
       // Should be called with the provided version
-      expect(setApiVersionSpy).toHaveBeenCalledWith('21');
       expect(mockExit).toHaveBeenCalledWith(0);
 
       consoleLogSpy.mockRestore();
-      setApiVersionSpy.mockRestore();
     });
   });
 
@@ -376,8 +341,6 @@ describe('validate command', () => {
       const mockContent = `const query = \`SELECT campaign.id FROM campaign\`;`;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -412,8 +375,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'json', color: false });
@@ -439,8 +400,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'json', color: false });
@@ -463,8 +422,6 @@ describe('validate command', () => {
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'json', color: false });
@@ -486,8 +443,6 @@ describe('validate command', () => {
       `;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -513,13 +468,11 @@ describe('validate command', () => {
 
       const validateTextSpy = vi.spyOn(core, 'validateText');
 
-      const { validateCommand } = await import('./validate.js');
-
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
       await validateCommand('test.ts', { apiVersion: '21', format: 'json', color: false });
 
-      expect(validateTextSpy).toHaveBeenCalledWith(mockContent);
+      expect(validateTextSpy).toHaveBeenCalledWith(mockContent, '21');
       expect(mockExit).toHaveBeenCalledWith(0);
 
       consoleLogSpy.mockRestore();
@@ -533,8 +486,6 @@ describe('validate command', () => {
       `;
 
       vi.mocked(fs.readFile).mockResolvedValue(mockContent);
-
-      const { validateCommand } = await import('./validate.js');
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -3,7 +3,6 @@ import { stdin } from 'node:process';
 import {
   type SupportedApiVersion,
   SupportedApiVersions,
-  setApiVersion,
   type ValidationResult,
   validateText,
 } from '@gaql/core';
@@ -30,7 +29,6 @@ export async function validateCommand(
     );
     process.exit(1);
   }
-  setApiVersion(version);
 
   // Read input
   const spinner = ora('Reading input...').start();
@@ -51,7 +49,7 @@ export async function validateCommand(
 
   // Validate
   spinner.start('Validating GAQL queries...');
-  const results = validateText(text);
+  const results = validateText(text, version);
   spinner.stop();
 
   // Output results

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Removed state-full api version management in favor of explicit version parameters in functions
+- Removed stateful api version management in favor of explicit version parameters in functions
 
 ## [0.1.3] - 2025-10-26
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-All notable changes to @gaql/core will be documented in this file.
+## [0.1.4] - 2025-10-29
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### Changed
+
+- Removed state-full api version management in favor of explicit version parameters in functions
 
 ## [0.1.3] - 2025-10-26
 
@@ -38,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- `setApiVersion()` / `getApiVersion()` - API version management
 - `getResourceNames()` - Get available resource names
 - `getFieldsForResource()` - Get fields for a specific resource
 - `getMetricsForResource()` - Get metrics for a resource
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/core-v0.1.1

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,10 +20,7 @@ npm install @gaql/core
 ### Basic Validation
 
 ```typescript
-import { validateQuery, setApiVersion } from '@gaql/core';
-
-// Set API version (default: 21)
-setApiVersion('21');
+import { validateQuery } from '@gaql/core';
 
 // Validate a query
 const query = `
@@ -109,12 +106,9 @@ console.log(result.suggestions);
 
 ### Schema Functions
 
-- `setApiVersion(version: '19' | '20' | '21')`: Set the Google Ads API version
-- `getApiVersion()`: Get the current API version
 - `getResourceNames()`: Get all available resource names
 - `getFieldsForResource(resource: string)`: Get all fields for a resource
 - `getFieldsForResourcePrefix(resource: string, prefix: string)`: Get fields for a specific prefix
-- `getResourcePrefixesForResource(resource: string)`: Get all resource prefixes
 - `getMetricsForResource(resource: string)`: Get metrics for a resource
 - `getSegmentsForResource(resource: string)`: Get segments for a resource
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "pretest": "node scripts/extract.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ui": "vitest --ui --coverage",
     "extract": "node scripts/extract.js",
     "prepublishOnly": "pnpm build"
   },
@@ -72,6 +73,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.0",
+    "@vitest/coverage-v8": "4.0.3",
     "typescript": "^5.9.3",
     "vitest": "^4.0.3"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gaql/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Core validation and schema logic for Google Ads Query Language (GAQL)",
   "license": "MIT",
   "author": {
@@ -58,19 +58,20 @@
     "build": "tsc --build",
     "dev": "tsc --build --watch",
     "clean": "rm -rf dist *.tsbuildinfo",
-    "lint": "biome check .",
-    "format": "biome format --write .",
+    "lint": "biome check --write --assist-enabled=true .",
     "pretest": "node scripts/extract.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "extract": "node scripts/extract.js",
     "prepublishOnly": "pnpm build"
   },
-  "devDependencies": {
-    "@biomejs/biome": "^2.3.0",
+  "dependencies": {
     "google-ads-api-v19": "npm:google-ads-api@^19.0.2",
     "google-ads-api-v20": "npm:google-ads-api@^20.0.1",
-    "google-ads-api-v21": "npm:google-ads-api@^21.0.1",
+    "google-ads-api-v21": "npm:google-ads-api@^21.0.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.3"
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,3 @@
-// Schema exports
-
-// Parser exports
 export {
   type CompletionItem,
   determineContext,
@@ -14,22 +11,25 @@ export {
 export {
   defaultApiVersion,
   type FieldDefinition,
+  fieldsDataV19,
+  fieldsDataV20,
+  fieldsDataV21,
   GAQL_KEYWORDS,
-  getApiVersion,
   getFieldsForResource,
   getFieldsForResourcePrefix,
   getMetricsForResource,
   getResourceInfo,
   getResourceNames,
-  getResourcePrefixesForResource,
   getSegmentsForResource,
   OPERATORS,
+  ResourceName,
+  ResourceNameV19,
+  ResourceNameV20,
+  ResourceNameV21,
   STATUS_VALUES,
   SupportedApiVersion,
   SupportedApiVersions,
-  setApiVersion,
 } from './schema.js';
-// Validator exports
 export {
   type ValidationError,
   ValidationErrorType,

--- a/packages/core/src/parser.test.ts
+++ b/packages/core/src/parser.test.ts
@@ -60,7 +60,7 @@ describe('parser.ts', () => {
   describe('Completions', () => {
     it('should return GAQL keywords in keyword context', () => {
       const query = '';
-      const result = getCompletions(query, 0);
+      const result = getCompletions(query, 0, '21');
 
       expect(result.context).toBe('keyword');
       expect(result.suggestions.length).toBeGreaterThan(0);
@@ -70,7 +70,7 @@ describe('parser.ts', () => {
 
     it('should return resource names in from_clause context', () => {
       const query = 'SELECT campaign.id FROM ';
-      const result = getCompletions(query, query.length);
+      const result = getCompletions(query, query.length, '21');
 
       // Context may be from_clause or keyword depending on regex matching
       expect(['from_clause', 'keyword']).toContain(result.context);
@@ -84,7 +84,7 @@ describe('parser.ts', () => {
 
     it('should return suggestions in select_fields context', () => {
       const query = 'SELECT ';
-      const result = getCompletions(query, query.length);
+      const result = getCompletions(query, query.length, '21');
 
       expect(['select_fields', 'keyword']).toContain(result.context);
       // In SELECT context, we should get some suggestions
@@ -93,7 +93,7 @@ describe('parser.ts', () => {
 
     it('should filter completions based on partial input', () => {
       const query = 'SELECT campaign.id FROM cam';
-      const result = getCompletions(query, query.length);
+      const result = getCompletions(query, query.length, '21');
 
       // Context depends on implementation
       expect(result.suggestions.length).toBeGreaterThan(0);
@@ -102,7 +102,7 @@ describe('parser.ts', () => {
 
     it('should have label, type, and description for each suggestion', () => {
       const query = '';
-      const result = getCompletions(query, 0);
+      const result = getCompletions(query, 0, '21');
 
       expect(result.suggestions.length).toBeGreaterThan(0);
       const suggestion = result.suggestions[0];
@@ -237,20 +237,20 @@ describe('parser.ts', () => {
   describe('Edge Cases', () => {
     it('should handle empty query for completions', () => {
       const query = '';
-      const result = getCompletions(query, 0);
+      const result = getCompletions(query, 0, '21');
       expect(result.suggestions.length).toBeGreaterThan(0);
     });
 
     it('should handle cursor position beyond query length', () => {
       const query = 'SELECT';
-      const result = getCompletions(query, 1000);
+      const result = getCompletions(query, 1000, '21');
       // Should not crash and should return some suggestions
       expect(Array.isArray(result.suggestions)).toBe(true);
     });
 
     it('should handle negative cursor position', () => {
       const query = 'SELECT campaign.id FROM campaign';
-      const result = getCompletions(query, -1);
+      const result = getCompletions(query, -1, '21');
       // Should not crash
       expect(Array.isArray(result.suggestions)).toBe(true);
     });
@@ -268,7 +268,7 @@ describe('parser.ts', () => {
     it('should provide field completions based on extracted resource', () => {
       const query = 'SELECT campaign.id FROM campaign WHERE campaign.';
       const resource = extractResource(query);
-      const result = getCompletions(query, query.length);
+      const result = getCompletions(query, query.length, '21');
 
       expect(resource).toBe('campaign');
       // Should get some suggestions
@@ -278,17 +278,17 @@ describe('parser.ts', () => {
     it('should handle complete query flow', () => {
       // Start with empty query
       let query = '';
-      let result = getCompletions(query, 0);
+      let result = getCompletions(query, 0, '21');
       expect(result.context).toBe('keyword');
 
       // Add SELECT
       query = 'SELECT ';
-      result = getCompletions(query, query.length);
+      result = getCompletions(query, query.length, '21');
       expect(['select_fields', 'keyword']).toContain(result.context);
 
       // Add field and FROM with trailing space
       query = 'SELECT campaign.id FROM ';
-      result = getCompletions(query, query.length);
+      result = getCompletions(query, query.length, '21');
       // Context depends on whether regex matches trailing space
       expect(['from_clause', 'keyword']).toContain(result.context);
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -321,7 +321,10 @@ export function extractWhereClause(query: string): string | null {
     let afterOrder = orderIdx + 5;
     while (afterOrder < upper.length && isWhitespaceChar(upper.charCodeAt(afterOrder)))
       afterOrder++;
-    if (upper.startsWith('BY', afterOrder) && (afterOrder + 2 >= upper.length || !isIdentCharCode(upper.charCodeAt(afterOrder + 2)))) {
+    if (
+      upper.startsWith('BY', afterOrder) &&
+      (afterOrder + 2 >= upper.length || !isIdentCharCode(upper.charCodeAt(afterOrder + 2)))
+    ) {
       end = orderIdx;
     }
   }

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -1,62 +1,34 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  getApiVersion,
   getFieldsForResource,
   getMetricsForResource,
   getResourceNames,
   getSegmentsForResource,
-  setApiVersion,
 } from './schema.js';
 
 describe('schema.ts', () => {
-  beforeEach(() => {
-    // Reset to default version before each test
-    setApiVersion('21');
-  });
-
-  describe('API Version Management', () => {
-    it('should set and get API version 19', () => {
-      setApiVersion('19');
-      expect(getApiVersion()).toBe('19');
-    });
-
-    it('should set and get API version 20', () => {
-      setApiVersion('20');
-      expect(getApiVersion()).toBe('20');
-    });
-
-    it('should set and get API version 21', () => {
-      setApiVersion('21');
-      expect(getApiVersion()).toBe('21');
-    });
-
-    it('should default to version 21', () => {
-      expect(getApiVersion()).toBe('21');
-    });
-  });
-
   describe('Resource Names', () => {
     it('should return an array of resource names', () => {
-      const resources = getResourceNames();
+      const resources = getResourceNames('21');
       expect(Array.isArray(resources)).toBe(true);
       expect(resources.length).toBeGreaterThan(0);
     });
 
     it('should include common resources', () => {
-      const resources = getResourceNames();
+      const resources = getResourceNames('21');
       expect(resources).toContain('campaign');
       expect(resources).toContain('ad_group');
       expect(resources).toContain('ad_group_ad');
     });
 
     it('should return unique resource names', () => {
-      const resources = getResourceNames();
+      const resources = getResourceNames('21');
       const uniqueResources = [...new Set(resources)];
       expect(resources.length).toBe(uniqueResources.length);
     });
 
     it('should be case-sensitive', () => {
-      const resources = getResourceNames();
+      const resources = getResourceNames('21');
       // Resource names should be lowercase with underscores
       for (const resource of resources) {
         expect(resource).toBe(resource.toLowerCase());
@@ -66,18 +38,19 @@ describe('schema.ts', () => {
 
   describe('Fields for Resource', () => {
     it('should return fields for campaign resource', () => {
-      const fields = getFieldsForResource('campaign');
+      const fields = getFieldsForResource('campaign', '21');
       expect(Array.isArray(fields)).toBe(true);
       expect(fields.length).toBeGreaterThan(0);
     });
 
     it('should return empty array for invalid resource', () => {
-      const fields = getFieldsForResource('invalid_resource_name');
+      // @ts-expect-error Testing invalid resource name
+      const fields = getFieldsForResource('invalid_resource_name', '21');
       expect(fields).toEqual([]);
     });
 
     it('should return fields with proper structure', () => {
-      const fields = getFieldsForResource('campaign');
+      const fields = getFieldsForResource('campaign', '21');
       expect(fields.length).toBeGreaterThan(0);
 
       const field = fields[0];
@@ -90,7 +63,7 @@ describe('schema.ts', () => {
     });
 
     it('should include id field for campaign resource', () => {
-      const fields = getFieldsForResource('campaign');
+      const fields = getFieldsForResource('campaign', '21');
       const idField = fields.find((f) => f.name === 'id');
       expect(idField).toBeDefined();
       // Field should have a type property
@@ -98,11 +71,8 @@ describe('schema.ts', () => {
     });
 
     it('should handle different API versions', () => {
-      setApiVersion('19');
-      const fieldsV19 = getFieldsForResource('campaign');
-
-      setApiVersion('21');
-      const fieldsV21 = getFieldsForResource('campaign');
+      const fieldsV19 = getFieldsForResource('campaign', '19');
+      const fieldsV21 = getFieldsForResource('campaign', '21');
 
       // Both versions should have fields
       expect(fieldsV19.length).toBeGreaterThan(0);
@@ -112,18 +82,19 @@ describe('schema.ts', () => {
 
   describe('Metrics for Resource', () => {
     it('should return metrics for campaign resource', () => {
-      const metrics = getMetricsForResource('campaign');
+      const metrics = getMetricsForResource('campaign', '21');
       expect(Array.isArray(metrics)).toBe(true);
       expect(metrics.length).toBeGreaterThan(0);
     });
 
     it('should return empty array for invalid resource', () => {
-      const metrics = getMetricsForResource('invalid_resource_name');
+      // @ts-expect-error Testing invalid resource name
+      const metrics = getMetricsForResource('invalid_resource_name', '21');
       expect(metrics).toEqual([]);
     });
 
     it('should have proper structure', () => {
-      const metrics = getMetricsForResource('campaign');
+      const metrics = getMetricsForResource('campaign', '21');
       if (metrics.length > 0) {
         const metric = metrics[0];
         expect(metric).toHaveProperty('name');
@@ -133,7 +104,7 @@ describe('schema.ts', () => {
     });
 
     it('should include common metrics', () => {
-      const metrics = getMetricsForResource('campaign');
+      const metrics = getMetricsForResource('campaign', '21');
       // Metrics should exist for campaign resource
       expect(metrics.length).toBeGreaterThan(0);
       // Check that metrics have proper structure
@@ -147,18 +118,19 @@ describe('schema.ts', () => {
 
   describe('Segments for Resource', () => {
     it('should return segments for resources that support them', () => {
-      const segments = getSegmentsForResource('campaign');
+      const segments = getSegmentsForResource('campaign', '21');
       expect(Array.isArray(segments)).toBe(true);
       // Segments may be empty for some resources
     });
 
     it('should return empty array for invalid resource', () => {
-      const segments = getSegmentsForResource('invalid_resource_name');
+      // @ts-expect-error Testing invalid resource name
+      const segments = getSegmentsForResource('invalid_resource_name', '21');
       expect(segments).toEqual([]);
     });
 
     it('should have proper structure when segments exist', () => {
-      const segments = getSegmentsForResource('campaign');
+      const segments = getSegmentsForResource('campaign', '21');
       if (segments.length > 0) {
         const segment = segments[0];
         expect(segment).toHaveProperty('name');

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   getApiVersion,
   getFieldsForResource,
+  getFieldsForResourcePrefix,
   getMetricsForResource,
+  getResourceInfo,
   getResourceNames,
+  getResourcePrefixesForResource,
   getSegmentsForResource,
   setApiVersion,
 } from './schema.js';
@@ -164,6 +167,90 @@ describe('schema.ts', () => {
         expect(segment).toHaveProperty('name');
         expect(segment).toHaveProperty('type');
         expect(segment).toHaveProperty('description');
+      }
+    });
+  });
+
+  describe('Fields for Resource Prefix', () => {
+    it('should return fields for a specific resource prefix', () => {
+      const fields = getFieldsForResourcePrefix('campaign', 'campaign');
+      expect(Array.isArray(fields)).toBe(true);
+      expect(fields.length).toBeGreaterThan(0);
+    });
+
+    it('should return empty array for invalid resource', () => {
+      const fields = getFieldsForResourcePrefix('invalid_resource', 'campaign');
+      expect(fields).toEqual([]);
+    });
+
+    it('should return empty array for invalid prefix', () => {
+      const fields = getFieldsForResourcePrefix('campaign', 'invalid_prefix');
+      expect(fields).toEqual([]);
+    });
+
+    it('should have proper structure for prefix fields', () => {
+      const fields = getFieldsForResourcePrefix('campaign', 'campaign');
+      if (fields.length > 0) {
+        const field = fields[0];
+        expect(field).toHaveProperty('name');
+        expect(field).toHaveProperty('type');
+        expect(field).toHaveProperty('description');
+        expect(field.description).toMatch(/^campaign\./);
+      }
+    });
+  });
+
+  describe('Resource Prefixes for Resource', () => {
+    it('should return resource prefixes for campaign', () => {
+      const prefixes = getResourcePrefixesForResource('campaign');
+      expect(Array.isArray(prefixes)).toBe(true);
+      expect(prefixes.length).toBeGreaterThan(0);
+      expect(prefixes).toContain('campaign');
+    });
+
+    it('should return empty array for invalid resource', () => {
+      const prefixes = getResourcePrefixesForResource('invalid_resource_name');
+      expect(prefixes).toEqual([]);
+    });
+
+    it('should return sorted prefixes', () => {
+      const prefixes = getResourcePrefixesForResource('campaign');
+      const sortedPrefixes = [...prefixes].sort();
+      expect(prefixes).toEqual(sortedPrefixes);
+    });
+  });
+
+  describe('Resource Info', () => {
+    it('should return resource info for campaign', () => {
+      const info = getResourceInfo('campaign');
+      expect(info).not.toBeNull();
+      expect(info).toHaveProperty('name');
+      expect(info).toHaveProperty('fieldCount');
+      expect(info).toHaveProperty('metricCount');
+      expect(info).toHaveProperty('segmentCount');
+      expect(info).toHaveProperty('attributedResources');
+      expect(info?.name).toBe('campaign');
+    });
+
+    it('should return null for invalid resource', () => {
+      const info = getResourceInfo('invalid_resource_name');
+      expect(info).toBeNull();
+    });
+
+    it('should have correct field counts', () => {
+      const info = getResourceInfo('campaign');
+      expect(info?.fieldCount).toBeGreaterThan(0);
+      expect(typeof info?.fieldCount).toBe('number');
+      expect(typeof info?.metricCount).toBe('number');
+      expect(typeof info?.segmentCount).toBe('number');
+    });
+
+    it('should have sorted attributed resources', () => {
+      const info = getResourceInfo('campaign');
+      expect(Array.isArray(info?.attributedResources)).toBe(true);
+      if (info?.attributedResources) {
+        const sorted = [...info.attributedResources].sort();
+        expect(info.attributedResources).toEqual(sorted);
       }
     });
   });

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -172,7 +172,6 @@ describe('schema.ts', () => {
     });
   });
 
-
   describe('Resource Info', () => {
     it('should return resource info for campaign', () => {
       const info = getResourceInfo('campaign', '21');

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -5,7 +5,6 @@ import {
   getMetricsForResource,
   getResourceInfo,
   getResourceNames,
-  getResourcePrefixesForResource,
   getSegmentsForResource,
 } from './schema.js';
 
@@ -145,23 +144,24 @@ describe('schema.ts', () => {
 
   describe('Fields for Resource Prefix', () => {
     it('should return fields for a specific resource prefix', () => {
-      const fields = getFieldsForResourcePrefix('campaign', 'campaign');
+      const fields = getFieldsForResourcePrefix('campaign', 'campaign', '21');
       expect(Array.isArray(fields)).toBe(true);
       expect(fields.length).toBeGreaterThan(0);
     });
 
     it('should return empty array for invalid resource', () => {
-      const fields = getFieldsForResourcePrefix('invalid_resource', 'campaign');
+      // @ts-expect-error Testing invalid resource name
+      const fields = getFieldsForResourcePrefix('invalid_resource', 'campaign', '21');
       expect(fields).toEqual([]);
     });
 
     it('should return empty array for invalid prefix', () => {
-      const fields = getFieldsForResourcePrefix('campaign', 'invalid_prefix');
+      const fields = getFieldsForResourcePrefix('campaign', 'invalid_prefix', '21');
       expect(fields).toEqual([]);
     });
 
     it('should have proper structure for prefix fields', () => {
-      const fields = getFieldsForResourcePrefix('campaign', 'campaign');
+      const fields = getFieldsForResourcePrefix('campaign', 'campaign', '21');
       if (fields.length > 0) {
         const field = fields[0];
         expect(field).toHaveProperty('name');
@@ -172,29 +172,10 @@ describe('schema.ts', () => {
     });
   });
 
-  describe('Resource Prefixes for Resource', () => {
-    it('should return resource prefixes for campaign', () => {
-      const prefixes = getResourcePrefixesForResource('campaign');
-      expect(Array.isArray(prefixes)).toBe(true);
-      expect(prefixes.length).toBeGreaterThan(0);
-      expect(prefixes).toContain('campaign');
-    });
-
-    it('should return empty array for invalid resource', () => {
-      const prefixes = getResourcePrefixesForResource('invalid_resource_name');
-      expect(prefixes).toEqual([]);
-    });
-
-    it('should return sorted prefixes', () => {
-      const prefixes = getResourcePrefixesForResource('campaign');
-      const sortedPrefixes = [...prefixes].sort();
-      expect(prefixes).toEqual(sortedPrefixes);
-    });
-  });
 
   describe('Resource Info', () => {
     it('should return resource info for campaign', () => {
-      const info = getResourceInfo('campaign');
+      const info = getResourceInfo('campaign', '21');
       expect(info).not.toBeNull();
       expect(info).toHaveProperty('name');
       expect(info).toHaveProperty('fieldCount');
@@ -205,12 +186,13 @@ describe('schema.ts', () => {
     });
 
     it('should return null for invalid resource', () => {
-      const info = getResourceInfo('invalid_resource_name');
+      // @ts-expect-error Testing invalid resource name
+      const info = getResourceInfo('invalid_resource_name', '21');
       expect(info).toBeNull();
     });
 
     it('should have correct field counts', () => {
-      const info = getResourceInfo('campaign');
+      const info = getResourceInfo('campaign', '21');
       expect(info?.fieldCount).toBeGreaterThan(0);
       expect(typeof info?.fieldCount).toBe('number');
       expect(typeof info?.metricCount).toBe('number');
@@ -218,7 +200,7 @@ describe('schema.ts', () => {
     });
 
     it('should have sorted attributed resources', () => {
-      const info = getResourceInfo('campaign');
+      const info = getResourceInfo('campaign', '21');
       expect(Array.isArray(info?.attributedResources)).toBe(true);
       if (info?.attributedResources) {
         const sorted = [...info.attributedResources].sort();

--- a/packages/core/src/validator.test.ts
+++ b/packages/core/src/validator.test.ts
@@ -5,7 +5,7 @@ describe('validator.ts', () => {
   describe('Query Validation - Valid Queries', () => {
     it('should validate a correct GAQL query', () => {
       const query = 'SELECT campaign.id, campaign.name FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -14,7 +14,7 @@ describe('validator.ts', () => {
     it('should validate query with WHERE clause', () => {
       const query =
         'SELECT campaign.id, campaign.name FROM campaign WHERE campaign.status = "ENABLED"';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -22,7 +22,7 @@ describe('validator.ts', () => {
 
     it('should validate query with metrics', () => {
       const query = 'SELECT campaign.id, metrics.impressions, metrics.clicks FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -33,7 +33,7 @@ describe('validator.ts', () => {
         campaign.id,
         campaign.name
       FROM campaign`;
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -43,7 +43,7 @@ describe('validator.ts', () => {
   describe('Query Validation - Missing Clauses', () => {
     it('should detect missing SELECT clause', () => {
       const query = 'FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
@@ -53,7 +53,7 @@ describe('validator.ts', () => {
 
     it('should detect missing FROM clause', () => {
       const query = 'SELECT campaign.id, campaign.name';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
@@ -63,7 +63,7 @@ describe('validator.ts', () => {
 
     it('should detect both missing clauses', () => {
       const query = 'WHERE campaign.status = "ENABLED"';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThanOrEqual(2);
@@ -76,7 +76,7 @@ describe('validator.ts', () => {
   describe('Query Validation - Invalid Resource', () => {
     it('should detect invalid resource name', () => {
       const query = 'SELECT field FROM invalid_resource_name';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidResourceError = result.errors.find(
@@ -88,7 +88,7 @@ describe('validator.ts', () => {
 
     it('should suggest similar resource names', () => {
       const query = 'SELECT field FROM campain'; // Typo: campain instead of campaign
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidResourceError = result.errors.find(
@@ -105,7 +105,7 @@ describe('validator.ts', () => {
   describe('Query Validation - Invalid Fields', () => {
     it('should detect invalid field name', () => {
       const query = 'SELECT campaign.invalid_field FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidFieldError = result.errors.find(
@@ -117,7 +117,7 @@ describe('validator.ts', () => {
 
     it('should suggest similar field names', () => {
       const query = 'SELECT campaign.nam FROM campaign'; // Typo: nam instead of name
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidFieldError = result.errors.find(
@@ -133,7 +133,7 @@ describe('validator.ts', () => {
     it('should validate multiple fields', () => {
       const query =
         'SELECT campaign.id, campaign.invalid1, campaign.name, campaign.invalid2 FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidFieldErrors = result.errors.filter(
@@ -146,7 +146,7 @@ describe('validator.ts', () => {
   describe('Query Validation - Error Information', () => {
     it('should provide line and column information', () => {
       const query = 'SELECT campaign.invalid FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toHaveProperty('line');
@@ -158,7 +158,7 @@ describe('validator.ts', () => {
 
     it('should have descriptive error messages', () => {
       const query = 'SELECT campaign.invalid FROM campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors[0].message).toBeTruthy();
@@ -174,7 +174,7 @@ describe('validator.ts', () => {
           FROM campaign
         \`;
       `;
-      const results = validateText(text);
+      const results = validateText(text, '21');
 
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].valid).toBe(true);
@@ -185,7 +185,7 @@ describe('validator.ts', () => {
         const query1 = \`SELECT campaign.id FROM campaign\`;
         const query2 = \`SELECT ad_group.id FROM ad_group\`;
       `;
-      const results = validateText(text);
+      const results = validateText(text, '21');
 
       expect(results.length).toBe(2);
       expect(results[0].valid).toBe(true);
@@ -199,7 +199,7 @@ describe('validator.ts', () => {
           FROM campaign
         \`;
       `;
-      const results = validateText(text);
+      const results = validateText(text, '21');
 
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].valid).toBe(false);
@@ -211,7 +211,7 @@ describe('validator.ts', () => {
         const message = \`Hello World\`;
         const query = \`SELECT campaign.id FROM campaign\`;
       `;
-      const results = validateText(text);
+      const results = validateText(text, '21');
 
       // Should only find the actual GAQL query
       expect(results.length).toBe(1);
@@ -230,7 +230,7 @@ describe('validator.ts', () => {
             campaign.status = "ENABLED"
         \`;
       `;
-      const results = validateText(text);
+      const results = validateText(text, '21');
 
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].valid).toBe(true);
@@ -248,7 +248,7 @@ describe('validator.ts', () => {
         WHERE
           customer_client.client_customer = '\${this.customerId}'
       `;
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -264,7 +264,7 @@ describe('validator.ts', () => {
         WHERE
           campaign.name LIKE '%\${searchTerm}%'
       `;
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -281,7 +281,7 @@ describe('validator.ts', () => {
           campaign.id = '\${campaignId}'
           AND campaign.status = '\${status}'
       `;
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
@@ -296,7 +296,7 @@ describe('validator.ts', () => {
         WHERE
           campaign.id = '\${campaignId}'
       `;
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       const invalidFieldError = result.errors.find(
@@ -310,7 +310,7 @@ describe('validator.ts', () => {
   describe('Edge Cases', () => {
     it('should handle empty query', () => {
       const query = '';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
@@ -318,21 +318,21 @@ describe('validator.ts', () => {
 
     it('should handle query with only whitespace', () => {
       const query = '   \n  \t  ';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(false);
     });
 
     it('should be case-insensitive for keywords', () => {
       const query = 'select campaign.id from campaign';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
     });
 
     it('should handle extra whitespace', () => {
       const query = '  SELECT    campaign.id   ,   campaign.name   FROM    campaign  ';
-      const result = validateQuery(query);
+      const result = validateQuery(query, '21');
 
       expect(result.valid).toBe(true);
     });

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -1,3 +1,4 @@
+import { extractDottedIdentifiers, extractSelectClause, extractWhereClause } from './parser.js';
 import {
   getFieldsForResource,
   getResourceNames,
@@ -48,7 +49,32 @@ export interface ValidationResult {
 function stripTemplateLiteralInterpolations(query: string): string {
   // Replace ${...} with a placeholder to avoid validating interpolated expressions
   // We use a string literal placeholder to maintain query structure
-  return query.replace(/\$\{(?:[^{}]|\{[^}]*\})*\}/g, "'__PLACEHOLDER__'");
+  // Manual parsing instead of regex to avoid polynomial backtracking (ReDoS)
+  const parts: string[] = [];
+  let i = 0;
+  while (i < query.length) {
+    if (query[i] === '$' && i + 1 < query.length && query[i + 1] === '{') {
+      // Found ${, find the matching } by tracking brace depth
+      let depth = 1;
+      let j = i + 2;
+      while (j < query.length && depth > 0) {
+        if (query[j] === '{') depth++;
+        else if (query[j] === '}') depth--;
+        j++;
+      }
+      if (depth === 0) {
+        parts.push("'__PLACEHOLDER__'");
+        i = j;
+      } else {
+        parts.push(query[i]);
+        i++;
+      }
+    } else {
+      parts.push(query[i]);
+      i++;
+    }
+  }
+  return parts.join('');
 }
 
 /**
@@ -126,9 +152,9 @@ export function validateQuery<T extends SupportedApiVersion>(
   }
 
   // Validate fields in SELECT clause
-  const selectMatch = cleanedQuery.match(/\bSELECT\s+(.+?)\s+FROM/is);
-  if (selectMatch) {
-    const selectFields = selectMatch[1]
+  const selectClause = extractSelectClause(cleanedQuery);
+  if (selectClause) {
+    const selectFields = selectClause
       .split(',')
       .map((f) => f.trim())
       .filter((f) => f.length > 0);
@@ -158,12 +184,10 @@ export function validateQuery<T extends SupportedApiVersion>(
   }
 
   // Validate fields in WHERE clause
-  const whereMatch = cleanedQuery.match(/\bWHERE\s+(.+?)(\s+ORDER\s+BY|\s+LIMIT|$)/is);
-  if (whereMatch) {
-    const whereClause = whereMatch[1];
+  const whereClause = extractWhereClause(cleanedQuery);
+  if (whereClause) {
     // Extract field references (e.g., campaign.id, metrics.clicks)
-    const fieldRegex = /([a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*)/gi;
-    const whereFields = whereClause.match(fieldRegex) || [];
+    const whereFields = extractDottedIdentifiers(whereClause);
 
     const validFields = getFieldsForResource(resourceName, version);
     const validFieldDescriptions = validFields.map((f) => f.description);
@@ -273,12 +297,18 @@ export function validateText<T extends SupportedApiVersion>(
   const results: Array<ValidationResult & { query: string; line: number }> = [];
 
   // Extract queries from template literals
-  const queryRegex = /`([^`]*SELECT[^`]*FROM[^`]*)`/gi;
+  // Use a simple regex to match backtick strings, then check for SELECT/FROM separately
+  // to avoid polynomial backtracking (ReDoS) with nested quantifiers
+  const backtickRegex = /`([^`]*)`/g;
   let match: RegExpExecArray | null;
 
   // biome-ignore lint/suspicious/noAssignInExpressions: needed for regex matching
-  while ((match = queryRegex.exec(text)) !== null) {
-    const query = match[1].trim();
+  while ((match = backtickRegex.exec(text)) !== null) {
+    const content = match[1];
+    if (!/SELECT/i.test(content) || !/FROM/i.test(content)) {
+      continue;
+    }
+    const query = content.trim();
     const startPos = match.index;
     const lineNumber = text.substring(0, startPos).split('\n').length - 1;
 

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2025-10-29
+
+### Changed
+
+- Update `@gaql/core` to v0.1.4
+
 ## [0.1.3] - 2025-10-26
 
 ### Changed
@@ -50,6 +56,7 @@
 
 ---
 
+[0.1.4]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.4
 [0.1.3]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.3
 [0.1.2]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.2
 [0.1.1]: https://github.com/kage1020/google-ads-query-language/releases/tag/vscode-extension-v0.1.1

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "gaql-vscode",
   "displayName": "Google Ads Query Language",
   "description": "Language support for Google Ads Query Language (GAQL): validation, autocomplete, IntelliSense, and diagnostics",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "kage1020",
   "author": {
     "name": "kage1020"
@@ -107,8 +107,7 @@
     "build": "vite build --config vite.config.build.ts",
     "dev": "vite build --config vite.config.build.ts --watch",
     "clean": "rm -rf out *.tsbuildinfo",
-    "lint": "biome check .",
-    "format": "biome format --write .",
+    "lint": "biome check --write --assist-enabled=true .",
     "test": "vitest run",
     "test:watch": "vitest",
     "package": "vsce package --no-dependencies",

--- a/packages/vscode-extension/src/completion.ts
+++ b/packages/vscode-extension/src/completion.ts
@@ -1,6 +1,6 @@
 import { getCompletions } from '@gaql/core';
 import * as vscode from 'vscode';
-import { getActivationMode, getEnabled } from './config.js';
+import { getActivationMode, getApiVersion, getEnabled } from './config.js';
 
 export class GAQLCompletionProvider implements vscode.CompletionItemProvider {
   public provideCompletionItems(
@@ -29,7 +29,8 @@ export class GAQLCompletionProvider implements vscode.CompletionItemProvider {
     }
 
     // Use @gaql/core to get completions
-    const result = getCompletions(query, cursorOffset);
+    const version = getApiVersion();
+    const result = getCompletions(query, cursorOffset, version);
 
     // Convert to VSCode CompletionItems
     return result.suggestions.map((suggestion) => {

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -1,6 +1,15 @@
 import { defaultApiVersion, type SupportedApiVersion } from '@gaql/core';
 import * as vscode from 'vscode';
 
+const configPrefix = 'gaql' as const;
+export const configName = {
+  prefix: configPrefix,
+  apiVersion: 'apiVersion',
+  language: 'language',
+  enabled: 'enabled',
+  activationMode: 'activationMode',
+} as const;
+
 /**
  * Get configuration value
  * @param key Configuration key (without prefix)
@@ -8,7 +17,7 @@ import * as vscode from 'vscode';
  * @returns Configuration value
  */
 function getConfigValue<T>(key: string, defaultValue: T): T {
-  const config = vscode.workspace.getConfiguration('gaql');
+  const config = vscode.workspace.getConfiguration(configPrefix);
   return config.get<T>(key, defaultValue);
 }
 
@@ -16,26 +25,26 @@ function getConfigValue<T>(key: string, defaultValue: T): T {
  * Get whether GAQL validation is enabled
  */
 export function getEnabled(): boolean {
-  return getConfigValue('enabled', true);
+  return getConfigValue(configName.enabled, true);
 }
 
 /**
  * Get activation mode
  */
 export function getActivationMode(): 'always' | 'onDemand' {
-  return getConfigValue<'always' | 'onDemand'>('activationMode', 'onDemand');
+  return getConfigValue<'always' | 'onDemand'>(configName.activationMode, 'onDemand');
 }
 
 /**
  * Get API version
  */
 export function getApiVersion(): SupportedApiVersion {
-  return getConfigValue<SupportedApiVersion>('apiVersion', defaultApiVersion);
+  return getConfigValue<SupportedApiVersion>(configName.apiVersion, defaultApiVersion);
 }
 
 /**
  * Get language setting
  */
 export function getLanguage(): string {
-  return getConfigValue('language', 'auto');
+  return getConfigValue(configName.language, 'auto');
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -12,8 +12,6 @@ export function activate(context: vscode.ExtensionContext) {
   // Initialize localization
   initializeLocalization(getLanguage());
 
-  const version = getApiVersion();
-
   // Register completion provider
   const completionProvider = vscode.languages.registerCompletionItemProvider(
     supportedCodeLanguages,
@@ -47,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
       if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
-        validator.validateDocument(document, version);
+        validator.validateDocument(document, getApiVersion());
       }
     }),
   );
@@ -56,7 +54,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
       if (supportedCodeLanguages.includes(event.document.languageId as SupportedCodeLanguage)) {
-        validator.validateDocument(event.document, version);
+        validator.validateDocument(event.document, getApiVersion());
       }
     }),
   );
@@ -67,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (editor) {
         const document = editor.document;
         if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
-          validator.validateDocument(document, version);
+          validator.validateDocument(document, getApiVersion());
         }
       }
     }),
@@ -77,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
   if (vscode.window.activeTextEditor) {
     const document = vscode.window.activeTextEditor.document;
     if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
-      validator.validateDocument(document, version);
+      validator.validateDocument(document, getApiVersion());
     }
   }
 
@@ -85,12 +83,9 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration(`${configName.prefix}.${configName.apiVersion}`)) {
-        const newVersion = getApiVersion();
-
-        // Re-validate all open documents
         for (const document of vscode.workspace.textDocuments) {
           if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
-            validator.validateDocument(document, newVersion);
+            validator.validateDocument(document, getApiVersion());
           }
         }
       }
@@ -102,7 +97,7 @@ export function activate(context: vscode.ExtensionContext) {
         // Re-validate all open documents to update error messages
         for (const document of vscode.workspace.textDocuments) {
           if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
-            validator.validateDocument(document, version);
+            validator.validateDocument(document, getApiVersion());
           }
         }
       }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,39 +1,38 @@
-import { setApiVersion } from '@gaql/core';
 import * as vscode from 'vscode';
 import { GAQLCompletionProvider } from './completion.js';
-import { getApiVersion, getLanguage } from './config.js';
+import { configName, getApiVersion, getLanguage } from './config.js';
 import { GAQLHoverProvider } from './hover.js';
 import { initializeLocalization, updateLanguage } from './localization.js';
 import { GAQLCodeActionProvider, GAQLValidator } from './validator.js';
 
+const supportedCodeLanguages = ['typescript', 'javascript'] as const;
+type SupportedCodeLanguage = (typeof supportedCodeLanguages)[number];
+
 export function activate(context: vscode.ExtensionContext) {
   // Initialize localization
-  const language = getLanguage();
-  initializeLocalization(language);
+  initializeLocalization(getLanguage());
 
-  // Initialize API version
-  const apiVersion = getApiVersion();
-  setApiVersion(apiVersion);
+  const version = getApiVersion();
 
   // Register completion provider
   const completionProvider = vscode.languages.registerCompletionItemProvider(
-    ['typescript', 'javascript'],
+    supportedCodeLanguages,
     new GAQLCompletionProvider(),
-    '.', // Triggered by dot
-    ' ', // Triggered by space
-    '\n', // Triggered by newline
-    '@', // Triggered by @ for directives
+    '.',
+    ' ',
+    '\n',
+    '@',
   );
 
   // Register hover provider
   const hoverProvider = vscode.languages.registerHoverProvider(
-    ['typescript', 'javascript'],
+    supportedCodeLanguages,
     new GAQLHoverProvider(),
   );
 
   // Register code action provider (Quick Fix)
   const codeActionProvider = vscode.languages.registerCodeActionsProvider(
-    ['typescript', 'javascript'],
+    supportedCodeLanguages,
     new GAQLCodeActionProvider(),
     {
       providedCodeActionKinds: GAQLCodeActionProvider.providedCodeActionKinds,
@@ -41,14 +40,14 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   // Create diagnostic collection for validation
-  const diagnosticCollection = vscode.languages.createDiagnosticCollection('gaql');
+  const diagnosticCollection = vscode.languages.createDiagnosticCollection(configName.prefix);
   const validator = new GAQLValidator(diagnosticCollection);
 
   // Validate on document open
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
-      if (document.languageId === 'typescript' || document.languageId === 'javascript') {
-        validator.validateDocument(document);
+      if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
+        validator.validateDocument(document, version);
       }
     }),
   );
@@ -56,11 +55,8 @@ export function activate(context: vscode.ExtensionContext) {
   // Validate on document change
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
-      if (
-        event.document.languageId === 'typescript' ||
-        event.document.languageId === 'javascript'
-      ) {
-        validator.validateDocument(event.document);
+      if (supportedCodeLanguages.includes(event.document.languageId as SupportedCodeLanguage)) {
+        validator.validateDocument(event.document, version);
       }
     }),
   );
@@ -70,8 +66,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor) {
         const document = editor.document;
-        if (document.languageId === 'typescript' || document.languageId === 'javascript') {
-          validator.validateDocument(document);
+        if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
+          validator.validateDocument(document, version);
         }
       }
     }),
@@ -80,34 +76,33 @@ export function activate(context: vscode.ExtensionContext) {
   // Validate current document on activation
   if (vscode.window.activeTextEditor) {
     const document = vscode.window.activeTextEditor.document;
-    if (document.languageId === 'typescript' || document.languageId === 'javascript') {
-      validator.validateDocument(document);
+    if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
+      validator.validateDocument(document, version);
     }
   }
 
   // Listen for configuration changes
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('gaql.apiVersion')) {
+      if (event.affectsConfiguration(`${configName.prefix}.${configName.apiVersion}`)) {
         const newVersion = getApiVersion();
-        setApiVersion(newVersion);
 
         // Re-validate all open documents
         for (const document of vscode.workspace.textDocuments) {
-          if (document.languageId === 'typescript' || document.languageId === 'javascript') {
-            validator.validateDocument(document);
+          if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
+            validator.validateDocument(document, newVersion);
           }
         }
       }
 
-      if (event.affectsConfiguration('gaql.language')) {
+      if (event.affectsConfiguration(`${configName.prefix}.${configName.language}`)) {
         const newLanguage = getLanguage();
         updateLanguage(newLanguage);
 
         // Re-validate all open documents to update error messages
         for (const document of vscode.workspace.textDocuments) {
-          if (document.languageId === 'typescript' || document.languageId === 'javascript') {
-            validator.validateDocument(document);
+          if (supportedCodeLanguages.includes(document.languageId as SupportedCodeLanguage)) {
+            validator.validateDocument(document, version);
           }
         }
       }

--- a/packages/vscode-extension/src/hover.ts
+++ b/packages/vscode-extension/src/hover.ts
@@ -4,9 +4,11 @@ import {
   getFieldsForResource,
   getResourceInfo,
   getResourceNames,
+  type ResourceName,
+  type SupportedApiVersion,
 } from '@gaql/core';
 import * as vscode from 'vscode';
-import { getEnabled } from './config.js';
+import { getApiVersion, getEnabled } from './config.js';
 
 export class GAQLHoverProvider implements vscode.HoverProvider {
   public provideHover(
@@ -45,9 +47,10 @@ export class GAQLHoverProvider implements vscode.HoverProvider {
     }
 
     // Check if it's a resource name
-    const resourceNames = getResourceNames();
-    if (resourceNames.includes(word)) {
-      const resourceInfo = getResourceInfo(word);
+    const version = getApiVersion();
+    const resourceNames = getResourceNames(version);
+    if (resourceNames.includes(word as ResourceName<SupportedApiVersion>)) {
+      const resourceInfo = getResourceInfo(word as ResourceName<SupportedApiVersion>, version);
       if (resourceInfo) {
         const markdown = new vscode.MarkdownString();
         markdown.appendMarkdown(`**Resource**: \`${resourceInfo.name}\`\n\n`);
@@ -75,7 +78,7 @@ export class GAQLHoverProvider implements vscode.HoverProvider {
     }
 
     // Get all fields for the resource
-    const fields = getFieldsForResource(resource);
+    const fields = getFieldsForResource(resource, version);
 
     // Find matching field
     const field = fields.find((f) => f.description === word || f.name === word);

--- a/packages/vscode-extension/src/validator.test.ts
+++ b/packages/vscode-extension/src/validator.test.ts
@@ -87,7 +87,7 @@ describe('GAQLValidator', () => {
         uri: { fsPath: 'test.ts' },
       } as vscode.TextDocument;
 
-      await validator.validateDocument(document);
+      await validator.validateDocument(document, '21');
 
       const mockSet = diagnosticCollection.set as Mock;
       const setCalls = mockSet.mock.calls as Array<
@@ -122,7 +122,7 @@ describe('GAQLValidator', () => {
         uri: { fsPath: 'test.ts' },
       } as vscode.TextDocument;
 
-      await validator.validateDocument(document);
+      await validator.validateDocument(document, '21');
 
       const mockSet = diagnosticCollection.set as Mock;
       const setCalls = mockSet.mock.calls as Array<
@@ -163,7 +163,7 @@ describe('GAQLValidator', () => {
         uri: { fsPath: 'test.ts' },
       } as vscode.TextDocument;
 
-      await validator.validateDocument(document);
+      await validator.validateDocument(document, '21');
 
       const mockSet = diagnosticCollection.set as Mock;
       const setCalls = mockSet.mock.calls as Array<

--- a/packages/vscode-extension/src/validator.ts
+++ b/packages/vscode-extension/src/validator.ts
@@ -1,4 +1,9 @@
-import { type ValidationError, ValidationErrorType, validateQuery } from '@gaql/core';
+import {
+  type SupportedApiVersion,
+  type ValidationError,
+  ValidationErrorType,
+  validateQuery,
+} from '@gaql/core';
 import * as vscode from 'vscode';
 import { getActivationMode, getEnabled } from './config.js';
 import { getMessage, MessageKey } from './localization.js';
@@ -16,7 +21,10 @@ export class GAQLValidator {
   /**
    * Validate GAQL queries in the document
    */
-  public async validateDocument(document: vscode.TextDocument): Promise<void> {
+  public async validateDocument<T extends SupportedApiVersion>(
+    document: vscode.TextDocument,
+    version: T,
+  ): Promise<void> {
     const enabled = getEnabled();
     if (!enabled) {
       this.diagnosticCollection.set(document.uri, []);
@@ -42,7 +50,7 @@ export class GAQLValidator {
       }
 
       // Validate query using @gaql/core
-      const result = validateQuery(query.text);
+      const result = validateQuery(query.text, version);
 
       // Convert validation errors to VS Code diagnostics
       for (const error of result.errors) {
@@ -83,7 +91,11 @@ export class GAQLValidator {
   private extractQueries(
     text: string,
   ): Array<{ text: string; startLine: number; disabled: boolean }> {
-    const queries: Array<{ text: string; startLine: number; disabled: boolean }> = [];
+    const queries: Array<{
+      text: string;
+      startLine: number;
+      disabled: boolean;
+    }> = [];
     const lines = text.split('\n');
 
     let backtickCount = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.0
         version: 2.3.0
+      '@vitest/coverage-v8':
+        specifier: 4.0.3
+        version: 4.0.3(vitest@4.0.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -169,9 +172,26 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.3.0':
     resolution: {integrity: sha512-shdUY5H3S3tJVUWoVWo5ua+GdPW5lRHf+b0IwZ4OC1o2zOKQECZ6l2KbU6t89FNhtd3Qx5eg5N7/UsQWGQbAFw==}
@@ -416,8 +436,15 @@ packages:
     resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -695,6 +722,15 @@ packages:
     resolution: {integrity: sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==}
     engines: {node: '>=20.0.0'}
 
+  '@vitest/coverage-v8@4.0.3':
+    resolution: {integrity: sha512-I+MlLwyJRBjmJr1kFYSxoseINbIdpxIAeK10jmXgB0FUtIfdYsvM3lGAvBu5yk8WPyhefzdmbCHCc1idFbNRcg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.3
+      vitest: 4.0.3
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.0.3':
     resolution: {integrity: sha512-v3eSDx/bF25pzar6aEJrrdTXJduEBU3uSGXHslIdGIpJVP8tQQHV6x1ZfzbFQ/bLIomLSbR/2ZCfnaEGkWkiVQ==}
 
@@ -833,6 +869,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.8:
+    resolution: {integrity: sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1377,6 +1416,9 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
@@ -1467,6 +1509,22 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
@@ -1477,6 +1535,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -1582,6 +1643,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
@@ -2458,7 +2526,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.3.0':
     optionalDependencies:
@@ -2612,7 +2693,14 @@ snapshots:
 
   '@isaacs/ttlcache@1.4.1': {}
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -2878,6 +2966,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.0.3(vitest@4.0.3)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.3
+      ast-v8-to-istanbul: 0.3.8
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.3.5
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.3(@types/node@24.9.1)(@vitest/ui@4.0.3)(happy-dom@20.0.8)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.0.3':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -3049,6 +3154,12 @@ snapshots:
   arrify@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.8:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   astral-regex@2.0.0: {}
 
@@ -3777,6 +3888,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-escaper@2.0.2: {}
+
   htmlparser2@10.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -3859,6 +3972,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   istextorbinary@9.5.0:
     dependencies:
       binaryextensions: 6.11.0
@@ -3870,6 +4004,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -3983,6 +4119,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   map-obj@4.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.0
         version: 2.3.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       turbo:
         specifier: ^2.5.8
         version: 2.5.8
@@ -56,10 +59,7 @@ importers:
         version: 4.0.3(@types/node@24.9.1)(@vitest/ui@4.0.3)(happy-dom@20.0.8)
 
   packages/core:
-    devDependencies:
-      '@biomejs/biome':
-        specifier: ^2.3.0
-        version: 2.3.0
+    dependencies:
       google-ads-api-v19:
         specifier: npm:google-ads-api@^19.0.2
         version: google-ads-api@19.0.2
@@ -69,6 +69,10 @@ importers:
       google-ads-api-v21:
         specifier: npm:google-ads-api@^21.0.1
         version: google-ads-api@21.0.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.3.0
+        version: 2.3.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1391,6 +1395,11 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3803,6 +3812,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
This pull request refactors the way API versioning is handled in the codebase, moving from a stateful global approach to explicitly passing the version as a parameter to relevant functions. It also updates documentation, test setup, and developer tooling to align with this change and improve workflow consistency.

### API Version Management Refactor

* Removed stateful API version management (`setApiVersion` and `getApiVersion`) from `@gaql/core`; now, API version is passed directly as a parameter to functions like `validateText` and `validateQuery`. This change affects both implementation and documentation. [[1]](diffhunk://#diff-df1599837df1a6998830ded71b991bb48a9db1483d7c273eb1c22e13bf844572L6) [[2]](diffhunk://#diff-df1599837df1a6998830ded71b991bb48a9db1483d7c273eb1c22e13bf844572L33) [[3]](diffhunk://#diff-df1599837df1a6998830ded71b991bb48a9db1483d7c273eb1c22e13bf844572L54-R52) [[4]](diffhunk://#diff-7eb5f05e9df8fd39bfe2e12fec9151ad1eac23e9e7a4dd7891f4b2d1d450faf2R7) [[5]](diffhunk://#diff-7eb5f05e9df8fd39bfe2e12fec9151ad1eac23e9e7a4dd7891f4b2d1d450faf2L42) [[6]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L23-R23) [[7]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L112-L117) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58)

### Test and CLI Adjustments

* Updated CLI command and its tests to use the new explicit version parameter, removing all usage and testing of global API version state. [[1]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87R1-R5) [[2]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L52-L53) [[3]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L69-L70) [[4]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L87-L88) [[5]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L115-L116) [[6]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L138-L139) [[7]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L165-L166) [[8]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L194-L215) [[9]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L235-L236) [[10]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L256-L257) [[11]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L281-L282) [[12]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L308-L309) [[13]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L331-L332) [[14]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L357-L370) [[15]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L380-L381) [[16]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L415-L416) [[17]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L442-L443) [[18]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L466-L467) [[19]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L490-L491) [[20]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L516-R476) [[21]](diffhunk://#diff-5bd6ebc9770c70e86c1826e516333b03cb34deef0ba64fb5a5f136fe2eeecc87L537-L538)

### Documentation Updates

* Updated both main and package-level README files to remove references to deprecated API version management functions and show the new usage patterns. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58) [[2]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L23-R23) [[3]](diffhunk://#diff-af0c08d6f291aa75c55d4ad3ec19fd4b728edcf43a39c80d566f661b3b311c44L112-L117)

### Developer Tooling and Workflow

* Added a Husky pre-commit hook to enforce linting, building, and testing before commits; integrated Husky into the project dependencies and setup scripts. [[1]](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R22)
* Updated VSCode settings to use Biome for formatting and code actions, disabling Prettier and ESLint to avoid conflicts, and improved import organization on save.
* Refined CLI package lint command to enable assistive fixes during linting.